### PR TITLE
add DisableIntegrationTest to PnDataVault pipeline

### DIFF
--- a/ci/infra/root.yaml
+++ b/ci/infra/root.yaml
@@ -261,6 +261,7 @@ Resources:
       TemplateURL: !Sub 'https://s3.amazonaws.com/${PnCiCdTemplatesBucketName}/ci/builders/mvn-docker-codebuild.yaml'
       Parameters:
         GitHubProjectName: 'pn-data-vault'
+        DisableIntegrationTest: 'false'
         CodeArtifactDomainName: !Ref 'CodeArtifactDomainName'
         CodeArtifactRepositoryName: !Ref 'CodeArtifactRepositoryName'
         NotificationSNSTopic: !Ref 'NotificationSNSTopic'


### PR DESCRIPTION
Aggiunta property per la pipeline di data-vault per non skippare gli integration test.