### PR TITLE
Feature/pn 2565

### DIFF
--- a/cd-cli/cleanupInfrastructure.sh
+++ b/cd-cli/cleanupInfrastructure.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+    
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+}
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+
+usage() {
+      cat <<EOF
+    Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-p <aws-profile>] -r <aws-region> -e <env-type>
+
+    [-h]                      : this help message
+    [-v]                      : verbose mode
+    [-p <aws-profile>]        : aws cli profile (optional)
+    -r <aws-region>           : aws region as eu-south-1
+    -e <env-type>             : one of dev / uat / svil / coll / cert / prod
+    
+EOF
+  exit 1
+}
+
+parse_params() {
+  # default values of variables set from params
+  project_name=pn
+  work_dir=$HOME/tmp/deploy
+  aws_profile=""
+  aws_region=""
+  env_type=""
+
+  while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -v | --verbose) set -x ;;
+    -p | --profile) 
+      aws_profile="${2-}"
+      shift
+      ;;
+    -r | --region) 
+      aws_region="${2-}"
+      shift
+      ;;
+    -e | --env-name) 
+      env_type="${2-}"
+      shift
+      ;;
+    -w | --work-dir) 
+      work_dir="${2-}"
+      shift
+      ;;
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+  done
+
+  args=("$@")
+
+  # check required params and arguments
+  [[ -z "${env_type-}" ]] && usage 
+  [[ -z "${aws_region-}" ]] && usage
+  return 0
+}
+
+dump_params(){
+  echo ""
+  echo "######      PARAMETERS      ######"
+  echo "##################################"
+  echo "Project Name:       ${project_name}"
+  echo "Work directory:     ${work_dir}"
+  echo "Env Name:           ${env_type}"
+  echo "AWS region:         ${aws_region}"
+  echo "AWS profile:        ${aws_profile}"
+}
+
+
+# START SCRIPT
+
+parse_params "$@"
+dump_params
+
+
+cd $work_dir
+
+echo ""
+echo "=== Base AWS command parameters"
+aws_command_base_args=""
+if ( [ ! -z "${aws_profile}" ] ) then
+  aws_command_base_args="${aws_command_base_args} --profile $aws_profile"
+fi
+if ( [ ! -z "${aws_region}" ] ) then
+  aws_command_base_args="${aws_command_base_args} --region  $aws_region"
+fi
+echo ${aws_command_base_args}
+
+logGroups=$(aws ${aws_command_base_args} logs describe-log-groups --output json | jq '.logGroups |  map(select(.retentionInDays == null)) | map(.logGroupName)')
+echo $logGroups
+
+updateRetention(){
+  echo "Setting retentiong on $1 to $2 days"
+  aws ${aws_command_base_args} logs put-retention-policy --log-group-name $1 --retention-in-days $2 
+}
+
+for logGroup in $(echo "${logGroups}" | jq -r '.[]'); do
+  updateRetention $logGroup 14
+done

--- a/cd-cli/cleanupInfrastructure.sh
+++ b/cd-cli/cleanupInfrastructure.sh
@@ -13,13 +13,12 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 usage() {
       cat <<EOF
-    Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-p <aws-profile>] -r <aws-region> -e <env-type>
+    Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-p <aws-profile>] -r <aws-region>
 
     [-h]                      : this help message
     [-v]                      : verbose mode
     [-p <aws-profile>]        : aws cli profile (optional)
     -r <aws-region>           : aws region as eu-south-1
-    -e <env-type>             : one of dev / uat / svil / coll / cert / prod
     
 EOF
   exit 1
@@ -45,10 +44,6 @@ parse_params() {
       aws_region="${2-}"
       shift
       ;;
-    -e | --env-name) 
-      env_type="${2-}"
-      shift
-      ;;
     -w | --work-dir) 
       work_dir="${2-}"
       shift
@@ -62,7 +57,6 @@ parse_params() {
   args=("$@")
 
   # check required params and arguments
-  [[ -z "${env_type-}" ]] && usage 
   [[ -z "${aws_region-}" ]] && usage
   return 0
 }
@@ -73,7 +67,6 @@ dump_params(){
   echo "##################################"
   echo "Project Name:       ${project_name}"
   echo "Work directory:     ${work_dir}"
-  echo "Env Name:           ${env_type}"
   echo "AWS region:         ${aws_region}"
   echo "AWS profile:        ${aws_profile}"
 }

--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -1027,7 +1027,7 @@ Resources:
                 - 'echo "###                CLEANUP INFRASTRUCTURE            ###"'
                 - 'echo "#########################################################"'
                 - 'echo ""'
-                - '(cd scripts/cd-cli && ./cleanupInfrastructure.sh -w /tmp -i $pn_infra_commitId -r $AwsRegion)'                
+                - '(cd scripts/cd-cli && ./cleanupInfrastructure.sh -w /tmp -r $AwsRegion)'                
           artifacts:
             files:
               - '**/*'

--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -2477,7 +2477,7 @@ Resources:
     Condition: IsDevCondition
     Properties:
       LogGroupName: !Sub "/aws/codebuild/${RunTestsCodebuildProject}"
-      RetentionInDays: 30
+      RetentionInDays: 14
 
 Outputs:
   CdArtifactBucketName:

--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -1021,6 +1021,13 @@ Resources:
                 - 'echo "#########################################################"'
                 - 'echo ""'
                 - '(cd scripts/cd-cli && ./deployApiGwUsagePlan.sh -w /tmp -i $pn_infra_commitId -r $AwsRegion STANDARD_B2B B2B && ./deployApiGwUsagePlan.sh -w /tmp -i $pn_infra_commitId -r $AwsRegion APP_IO_BE IO)'
+                - 'echo ""'
+                - 'echo ""'
+                - 'echo "#########################################################"'
+                - 'echo "###                CLEANUP INFRASTRUCTURE            ###"'
+                - 'echo "#########################################################"'
+                - 'echo ""'
+                - '(cd scripts/cd-cli && ./cleanupInfrastructure.sh -w /tmp -i $pn_infra_commitId -r $AwsRegion)'                
           artifacts:
             files:
               - '**/*'

--- a/cd-cli/cnf-templates/data-vault-only-pipeline.yaml
+++ b/cd-cli/cnf-templates/data-vault-only-pipeline.yaml
@@ -657,7 +657,7 @@ Resources:
                 - 'echo "###                CLEANUP INFRASTRUCTURE            ###"'
                 - 'echo "#########################################################"'
                 - 'echo ""'
-                - '(cd scripts/cd-cli && ./cleanupInfrastructure.sh -w /tmp -i $pn_infra_commitId -r $AwsRegion)'
+                - '(cd scripts/cd-cli && ./cleanupInfrastructure.sh -w /tmp -r $AwsRegion)'
           artifacts:
             files:
               - '**/*'

--- a/cd-cli/cnf-templates/data-vault-only-pipeline.yaml
+++ b/cd-cli/cnf-templates/data-vault-only-pipeline.yaml
@@ -400,6 +400,28 @@ Resources:
                 - Name: PnLogsaverBeOutput
               RunOrder: 4
 
+             # Update logs and Usage Plans
+            - Name: Infrastructure_Post_Deploy
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref PostDeployScriptsCodeBuildProject
+                PrimarySource: DesiredCommitIdsAndScripts
+                EnvironmentVariables: !Sub '[
+                    {"name":"EnvName", "value":"${EnvName}", "type":"PLAINTEXT"},
+                    {"name":"AwsRegion", "value":"${AWS::Region}", "type":"PLAINTEXT"},
+                    {"name":"CdArtifactBucketName", "value":"${CdArtifactBucket}", "type":"PLAINTEXT"},
+                    {"name":"CiArtifactBucketName", "value":"${CiArtifactBucketNameParam}", "type":"PLAINTEXT"}
+                  ]'
+              InputArtifacts:
+                - Name: DesiredCommitIdsAndScripts
+              OutputArtifacts:
+                - Name: PostDeployScriptsOutput
+              RunOrder: 5
+
             # List versions if the environment is dev
             - Fn::If:
                 - IsDevCondition
@@ -584,6 +606,58 @@ Resources:
                 - 'echo ""'
                 - 'echo "./deployPnDataVaultExternalService.sh -r $AwsRegion -e $EnvName -i $pn_infra_commitId -m $ms_commitId -b $CdArtifactBucketName -I $ms_image_url -n $MsName -N $MsNumber -w /tmp -c $custom_config_dir "'
                 - '(cd scripts/cd-cli && ./deployPnDataVaultExternalService.sh -r $AwsRegion -e $EnvName -i $pn_infra_commitId -m $ms_commitId -b $CdArtifactBucketName -I $ms_image_url -n $MsName -N $MsNumber -w /tmp -c $custom_config_dir )'
+          artifacts:
+            files:
+              - '**/*'
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Type: LINUX_CONTAINER
+        Image: "aws/codebuild/standard:5.0"
+
+  # CODEBUILD used to cleanup infrastructure after deploy #
+  #########################################################
+  PostDeployScriptsCodeBuildProject:
+    Type: 'AWS::CodeBuild::Project'
+    Properties:
+      Name: !Sub ${ProjectName}-PostDeployScriptsCodeBuildProject
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      Source: 
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            pre_build:
+              commands:
+                - VERSION=v4.20.1
+                - BINARY=yq_linux_amd64
+                - wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/bin/yq
+                - chmod +x /usr/bin/yq
+                - VERSION=`yq --version`
+                - echo "$VERSION"
+                - yq --version
+                - 'echo "### SCRIPTS ###"'
+                - 'find scripts'
+                - 'echo "### SOURCE DESIRED COMMIT IDS ###"'
+                - '. ./scripts/desired-commit-ids-env.sh'
+                - 'echo ""'
+                - 'echo "###     ENVIRONMENT     ###"'
+                - 'echo "###########################"'
+                - env
+            build:
+              commands:
+                - 'echo ""'
+                - 'echo ""'
+                - 'echo ""'
+                - 'echo ""'
+                - 'echo ""'
+                - 'echo ""'
+                - 'echo "#########################################################"'
+                - 'echo "###                CLEANUP INFRASTRUCTURE            ###"'
+                - 'echo "#########################################################"'
+                - 'echo ""'
+                - '(cd scripts/cd-cli && ./cleanupInfrastructure.sh -w /tmp -i $pn_infra_commitId -r $AwsRegion)'
           artifacts:
             files:
               - '**/*'


### PR DESCRIPTION
Added cleanup infrastructure script to the post deploy pipeline step (both data vault only and complete pipeline).
The script can be used also a standalone bash in order to set retention to **cicd** AWS account.