### PR TITLE
Feature/pnpaperchannel conditional

### DIFF
--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -716,28 +716,31 @@ Resources:
               RunOrder: 3
 
             # Update pn-paper-channel
-            - Name: Update_PnPaperChannel
-              ActionTypeId:
-                Category: Build
-                Owner: AWS
-                Version: 1
-                Provider: CodeBuild
-              Configuration:
-                ProjectName: !Ref UpdateMicroserviceCodeBuildProject
-                PrimarySource: DesiredCommitIdsAndScripts
-                EnvironmentVariables: !Sub '[
-                    {"name":"EnvName", "value":"${EnvName}", "type":"PLAINTEXT"},
-                    {"name":"AwsRegion", "value":"${AWS::Region}", "type":"PLAINTEXT"},
-                    {"name":"CdArtifactBucketName", "value":"${CdArtifactBucket}", "type":"PLAINTEXT"},
-                    {"name":"MsName", "value":"pn-paper-channel", "type":"PLAINTEXT"},
-                    {"name":"MsNumber", "value":"13", "type":"PLAINTEXT"},
-                    {"name":"VarPrefix", "value":"pn_paper_channel", "type":"PLAINTEXT"}
-                  ]'
-              InputArtifacts:
-                - Name: DesiredCommitIdsAndScripts
-              OutputArtifacts:
-                - Name: PnPaperChannelOutput
-              RunOrder: 3
+            - Fn::If:
+              - IsDevCondition
+              - Name: Update_PnPaperChannel
+                ActionTypeId:
+                  Category: Build
+                  Owner: AWS
+                  Version: 1
+                  Provider: CodeBuild
+                Configuration:
+                  ProjectName: !Ref UpdateMicroserviceCodeBuildProject
+                  PrimarySource: DesiredCommitIdsAndScripts
+                  EnvironmentVariables: !Sub '[
+                      {"name":"EnvName", "value":"${EnvName}", "type":"PLAINTEXT"},
+                      {"name":"AwsRegion", "value":"${AWS::Region}", "type":"PLAINTEXT"},
+                      {"name":"CdArtifactBucketName", "value":"${CdArtifactBucket}", "type":"PLAINTEXT"},
+                      {"name":"MsName", "value":"pn-paper-channel", "type":"PLAINTEXT"},
+                      {"name":"MsNumber", "value":"13", "type":"PLAINTEXT"},
+                      {"name":"VarPrefix", "value":"pn_paper_channel", "type":"PLAINTEXT"}
+                    ]'
+                InputArtifacts:
+                  - Name: DesiredCommitIdsAndScripts
+                OutputArtifacts:
+                  - Name: PnPaperChannelOutput
+                RunOrder: 3
+              - !Ref AWS::NoValue
 
             # Update Frontend
             - Name: Update_Frontend

--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -276,7 +276,7 @@ Resources:
                     sed -i -e "s|pn_apikey_manager_imageUrl=.*|pn_apikey_manager_imageUrl=$IMAGE_URL|" desired-commit-ids-env.sh
                     export PIPELINE_NAME="pn-pn-apikey-manager-update-pipeline"
                   fi
-                 - |
+                - |
                   if ( [ "$PROJECT" = "pn-paper-channel" ] ) then
                     sed -i -e "s|pn_paper_channel_commitId=.*|pn_paper_channel_commitId=$COMMIT_ID|" desired-commit-ids-env.sh
                     sed -i -e "s|pn_paper_channel_imageUrl=.*|pn_paper_channel_imageUrl=$IMAGE_URL|" desired-commit-ids-env.sh

--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -280,7 +280,7 @@ Resources:
                   if ( [ "$PROJECT" = "pn-paper-channel" ] ) then
                     sed -i -e "s|pn_paper_channel_commitId=.*|pn_paper_channel_commitId=$COMMIT_ID|" desired-commit-ids-env.sh
                     sed -i -e "s|pn_paper_channel_imageUrl=.*|pn_paper_channel_imageUrl=$IMAGE_URL|" desired-commit-ids-env.sh
-                    export PIPELINE_NAME="pn-pn-paper_channel-update-pipeline"
+                    export PIPELINE_NAME="pn-pn-paper-channel-update-pipeline"
                   fi
                 - 'cat desired-commit-ids-env.sh'
                 - 'echo "Upload commit configuration file"'


### PR DESCRIPTION
La PR è relativa a:

- rendere opzionale l'esecuzione del deploy pn-paper-channel nella pipeline deployAll
- correggere degli errori di configurazione creati con l'introduzione di pn-paper-channel: la commit https://github.com/pagopa/pn-cicd/commit/9bfab340378c0219e084c4d594866d74b93fd4ec risolve un problema che rende la ChooseCdPipeline non funzionante


