### PR TITLE
PN-11151-B: modify cron for E2E test BE

### DIFF
--- a/cd-cli/cnf-templates/complete-pipeline.yaml
+++ b/cd-cli/cnf-templates/complete-pipeline.yaml
@@ -5848,7 +5848,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "e2eScheduledRule"
-      ScheduleExpression: "cron(0 5 ? * MON-FRI *)"
+      ScheduleExpression: "cron(15 4 ? * MON-FRI *)"
       State: "ENABLED"
       RoleArn: !GetAtt "EventBusRunCodeBuildRole.Arn"
       Targets: 


### PR DESCRIPTION
su richiesta di QA anticipiamo il prima possibile il RUN dei test E2E di BE in modo che per le 8AM il run è sicuramente concluso