### PR TITLE
PN-13342: set CodeBuildProject ComputeType to BUILD_GENERAL1_MEDIUM for pn-external-registries too.

### DIFF
--- a/ci/builders/mvn-docker-codebuild.yaml
+++ b/ci/builders/mvn-docker-codebuild.yaml
@@ -142,11 +142,21 @@ Conditions:
     Fn::Equals:
       - Ref: ShouldCreateEcrParam
       - 'true'
-  
-  NeedMediumBuildEnv:
+
+  PnExternalRegistriesModule:
+    Fn::Equals:
+      - Ref: GitHubProjectName
+      - 'pn-external-registries'
+
+  PnDeliveryPushModule:
     Fn::Equals:
       - Ref: GitHubProjectName
       - 'pn-delivery-push'
+
+  NeedMediumBuildEnv:
+    Fn::Or:
+      - Condition: PnDeliveryPushModule
+      - Condition: PnExternalRegistriesModule
 
 Resources:
 


### PR DESCRIPTION
PN-13342: set CodeBuildProject ComputeType to BUILD_GENERAL1_MEDIUM for pn-external-registries too.