### PR TITLE
PN20901: add optional pytest support for python lambdas in multilambda bui…

### DIFF
--- a/ci/builders/multilambda-codebuild.yaml
+++ b/ci/builders/multilambda-codebuild.yaml
@@ -157,16 +157,17 @@ Resources:
                       echo "Running unit tests for $(pwd)"
                       local TEST_ENV_DIR TEST_EXIT_CODE
                       TEST_ENV_DIR=$(mktemp -d /tmp/pytest-env-XXXXXX)
+                      python -m venv "$TEST_ENV_DIR"
 
                       if [ -f "requirements.txt" ]; then
                         echo "Installing runtime dependencies into isolated test environment"
-                        python -m pip install --target "$TEST_ENV_DIR" -r requirements.txt
+                        "$TEST_ENV_DIR/bin/pip" install -r requirements.txt
                       fi
 
                       echo "Installing test dependencies into isolated test environment"
-                      python -m pip install --target "$TEST_ENV_DIR" -r tests/requirements-test.txt
+                      "$TEST_ENV_DIR/bin/pip" install -r tests/requirements-test.txt
 
-                      PYTHONPATH="$TEST_ENV_DIR" python -m pytest
+                      "$TEST_ENV_DIR/bin/python" -m pytest
                       TEST_EXIT_CODE=$?
 
                       rm -rf "$TEST_ENV_DIR"
@@ -204,7 +205,7 @@ Resources:
                         
                         # zip mantaining folder structure
                         echo "Creating function.zip with all files"
-                        zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "requirements.txt" -x "tests/*" -x ".pytest_cache/*"
+                        zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "requirements.txt" -x "tests/*" -x ".pytest_cache/*" -x ".coverage*" -x "coverage.xml" -x "htmlcov/*"
                       else
                         echo "Error: requirements.txt found but no Python files (*.py) detected in ${i}"
                         exit 1
@@ -214,7 +215,7 @@ Resources:
                       echo "Building Python function without dependencies"
                       run_python_tests
 
-                      zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "tests/*" -x ".pytest_cache/*"
+                      zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "tests/*" -x ".pytest_cache/*" -x ".coverage*" -x "coverage.xml" -x "htmlcov/*"
 
                     else
                       echo "No recognized function code found in ${i}, no package.json requirements.txt nor *.py files detected"

--- a/ci/builders/multilambda-codebuild.yaml
+++ b/ci/builders/multilambda-codebuild.yaml
@@ -152,6 +152,33 @@ Resources:
                 - cd $FUNCTIONS_FOLDER_NAME
                 - echo Build started on `date`
                 - |
+                  run_python_tests() {
+                    if [ -d "tests" ] && [ -f "tests/requirements-test.txt" ]; then
+                      echo "Running unit tests for $(pwd)"
+                      local TEST_ENV_DIR TEST_EXIT_CODE
+                      TEST_ENV_DIR=$(mktemp -d /tmp/pytest-env-XXXXXX)
+
+                      if [ -f "requirements.txt" ]; then
+                        echo "Installing runtime dependencies into isolated test environment"
+                        python -m pip install --target "$TEST_ENV_DIR" -r requirements.txt
+                      fi
+
+                      echo "Installing test dependencies into isolated test environment"
+                      python -m pip install --target "$TEST_ENV_DIR" -r tests/requirements-test.txt
+
+                      PYTHONPATH="$TEST_ENV_DIR" python -m pytest
+                      TEST_EXIT_CODE=$?
+
+                      rm -rf "$TEST_ENV_DIR"
+
+                      if [ $TEST_EXIT_CODE -ne 0 ]; then
+                        echo "Error: unit tests failed for $(pwd)"
+                        exit 1
+                      fi
+                    else
+                      echo "Skipping unit tests for $(pwd): tests/ directory or tests/requirements-test.txt not found"
+                    fi
+                  }
                   for i in */
                   do
                     echo "Building $i"
@@ -171,13 +198,13 @@ Resources:
                       echo "Using Python version: $(python --version)"
                       
                       if [ -n "$(find . -type f -name "*.py")" ]; then
-                        
+                        run_python_tests
                         echo "Installing dependencies from requirements.txt"
                         python -m pip install --target . -r requirements.txt
                         
                         # zip mantaining folder structure
                         echo "Creating function.zip with all files"
-                        zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "requirements.txt"
+                        zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "requirements.txt" -x "tests/*" -x ".pytest_cache/*"
                       else
                         echo "Error: requirements.txt found but no Python files (*.py) detected in ${i}"
                         exit 1
@@ -185,8 +212,10 @@ Resources:
                     # if no requiremnts.txt check for *.py files
                     elif [ -n "$(find . -type f -name "*.py")" ]; then
                       echo "Building Python function without dependencies"
-                      zip -r function.zip . -x "*.pyc" -x "__pycache__/*"
-                    
+                      run_python_tests
+
+                      zip -r function.zip . -x "*.pyc" -x "__pycache__/*" -x "tests/*" -x ".pytest_cache/*"
+
                     else
                       echo "No recognized function code found in ${i}, no package.json requirements.txt nor *.py files detected"
                       exit 1


### PR DESCRIPTION
This PR adds optional pytest support to the multilambda-codebuild pipeline for Python Lambdas.

- Added automatic test execution when tests/ and tests/requirements-test.txt are present.
- Created an isolated temporary environment for runtime and test dependencies.
- Configured the build to fail if unit tests do not pass.
- Excluded tests/ and .pytest_cache/ from the generated deployment package.